### PR TITLE
ci: use GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: Test & Build
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  test_and_build:
+    name: Test & Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+
+      - name: Install packages
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test
+
+      - name: Build site
+        run: npm run build --if-present
+
+      - name: Copy readme file
+        if: github.ref == 'master'
+        run: cp README.deploy dist/README.md
+
+      - name: Upload dist folder
+        if: github.ref == 'master'
+        uses: actions/upload-artifact@v1
+        with:
+          name: dist
+          path: ./dist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    needs: test_and_build
+
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download built dist folder
+        uses: actions/download-artifact@v1
+        with:
+          name: dist
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          external_repository: srcery-colors/srcery-colors.github.io
+          deploy_key: ${{ secrets.SRCERY_DEPLOY_KEY }}
+          publish_branch: master # deploying branch
+          publish_dir: ./dist


### PR DESCRIPTION
Seems to work at least for the build & test stage.  Not sure about the push to `master` yet.

Works faster than Travis CI.